### PR TITLE
Correct the links in the gazebo docs / add Dockerized way to run Gazebo examples

### DIFF
--- a/petoi_ROS_model_docs/Dockerfile
+++ b/petoi_ROS_model_docs/Dockerfile
@@ -1,0 +1,25 @@
+# This is an auto generated Dockerfile for ros:ros-base
+# generated from docker_images/create_ros_image.Dockerfile.em
+FROM osrf/ros:noetic-desktop-full
+
+# non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y git ros-noetic-effort-controllers
+
+# Set up the catkin workspace
+RUN mkdir -p /app/catkin_ws/src
+WORKDIR /app/catkin_ws
+RUN /bin/bash -c "source /opt/ros/noetic/setup.bash; catkin_make"
+
+# clone the opencat repo
+WORKDIR /app/catkin_ws/src
+RUN git clone https://github.com/PetoiCamp/ros_opencat.git
+
+# source /opt/ros/noetic/setup.bash
+# source /app/catkin_ws/devel/setup.bash
+RUN echo "source /opt/ros/noetic/setup.bash" >> /root/.bashrc
+RUN echo "source /app/catkin_ws/devel/setup.bash" >> /root/.bashrc
+
+# Set up the entrypoint
+ENTRYPOINT ["/bin/bash"]

--- a/petoi_ROS_model_docs/README.md
+++ b/petoi_ROS_model_docs/README.md
@@ -1,0 +1,8 @@
+If you wish to run Bittle or Nybble Gazebo / rviz inside the container,
+do the following first:
+```
+xhost +si:localuser:root
+docker-compose build
+docker-compose run --rm ros-rviz
+```
+Then proceed from **Launch Gazebo simulation** step in the docs.

--- a/petoi_ROS_model_docs/bittle_ros_documentation.md
+++ b/petoi_ROS_model_docs/bittle_ros_documentation.md
@@ -1,6 +1,6 @@
-# [Petoi](https://www.petoi.com/ "Petoi")  
+# [Petoi](https://www.petoi.com/ "Petoi")
 
-### Bittle ROS Documentation 
+### Bittle ROS Documentation
 This documentation is designed to configure Bittle in the ROS Simulation Environment.
 
 ### Pre-requisites 🤔
@@ -10,10 +10,10 @@ Your system must have:
 
 ### Tutorial 😃
 - #### [ROS Installation Steps](https://www.youtube.com/watch?v=ZA7u2XPmnlo)
-  
+
    Open the terminal and follow the below commands to install [ROS Noetic Ninjemys](http://wiki.ros.org/noetic/Installation/Ubuntu)
 
- 
+
 ```bash
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
  ```
@@ -21,52 +21,53 @@ Your system must have:
     sudo apt install curl # if you haven't already installed curl
  ```
 ```bash
- curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
+ curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 ```
 ```bash
 sudo apt update
 ```
-```bash 
-sudo apt install ros-noetic-desktop-full
+```bash
+sudo apt install ros-noetic-desktop-full ros-noetic-effort-controllers
 ```
 - #### Create Catkin Workspace for the ROS Packages
-  
 
-Follow the below mentioned commands to create a Catkin Workspace for creating and modifying the ROS packages. 
+Follow the below mentioned commands to create a Catkin Workspace for creating and modifying the ROS packages.
 
-```bash 
+```bash
 mkdir -p ~/catkin_ws/src
 ```
-```bash 
+```bash
 cd ~/catkin_ws/
 ```
-```bash 
+```bash
 catkin_make
 ```
-Open the ```~/.bashrc file``` via below command 
+Open the ```~/.bashrc file``` via below command
 
-```bash 
+```bash
 gedit ~/.bashrc
 ```
 .bashrc file will appear
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/bashrc.png " height ="100%" width="100%" alt text="bashrc file">
+<img src="bittle_ros_images/bashrc.png " height ="100%" width="100%" alt text="bashrc file">
 
 Paste the below commands in ```.bashrc file``` (screenshot has been attached for reference)
 
-```bash 
+```bash
 source /opt/ros/noetic/setup.bash
 source ~/catkin_ws/devel/setup.bash
 ```
 
 Clone the folder [bittle_description package](https://github.com/PetoiCamp/ros_opencat/tree/ros1/petoi_ros_docs/bittle_ros) and paste it inside the ```src``` folder of the catkin workspace.
 
+- #### Launch Gazebo simulation
+
 Start the ROS master via
 ```bash
 roscore
 ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/roscore.png">
+<img src="bittle_ros_images/roscore.png">
 
 Open a new terminal window or simply press ```Ctrl+Alt+T```and follow below mentioned commands to spawn your Bittle in an empty Gazebo Simulation Environment.
 
@@ -85,8 +86,8 @@ ls
 ```bash
 roslaunch bittle_description gazebo.launch
 ```
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/final.png">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/bittle_simulation.png">
+<img src="bittle_ros_images/final.png">
+<img src="bittle_ros_images/bittle_simulation.png">
 
 - #### Steps to launch your Bittle in the Gazebo world Simulation Environment
   <br>
@@ -102,7 +103,7 @@ $${\color{orange}processes. \space Just \space by \space simply \space pressing 
   roslaunch bittle_gazebo bittle_world.launch
   ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/bittle_world.png">
+<img src="bittle_ros_images/bittle_world.png">
 
 For launching controller for the joints of the Bittle.
 
@@ -111,8 +112,8 @@ For launching controller for the joints of the Bittle.
   ```
 Press the play button ▶️ in the Gazebo to load all the joint controllers.
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/controller_1.png">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/controller_2.png">
+<img src="bittle_ros_images/controller_1.png">
+<img src="bittle_ros_images/controller_2.png">
 
 For controlling the joint position of the neck you are required to install [joystick ros driver](http://wiki.ros.org/joy/Tutorials/ConfiguringALinuxJoystick) <br>
 [Video reference for installation of joystick driver](https://www.youtube.com/watch?v=4cSRdS83PX4&t=204s)
@@ -122,26 +123,26 @@ Open a new terminal window and launch your joystick package
   roslaunch bittle_joystick bittle_joystick.launch
   ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/joystick_2.png">
+<img src="bittle_ros_images/joystick_2.png">
 
-Open another terminal and run your joystick node 
+Open another terminal and run your joystick node
 ```bash
   rosrun bittle_joystick bittle_joystick.py
   ```
 Press `Enter`
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/joystick_1.jpeg">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/joystick.jpeg">
+<img src="bittle_ros_images/joystick_1.jpeg">
+<img src="bittle_ros_images/joystick.jpeg">
 
 Move this joystick button as mentioned in the above image to control the neck movement.
 
-To visualize your Bittle in Rviz(Robot Visualization) 
+To visualize your Bittle in Rviz(Robot Visualization)
 
 ```bash
    roslaunch bittle_description display.launch
   ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/rviz.png">
+<img src="bittle_ros_images/rviz.png">
 
 Open a new terminal to publish the joint angles for the different joints of the Bittle.
 ```bash
@@ -149,8 +150,8 @@ Open a new terminal to publish the joint angles for the different joints of the 
   ```
 You can move the joints by sliding the corresponding joints bar using `joint_state_publisher_gui` node.
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/bittle.gif" height="35%">
+<img src="bittle_ros_images/bittle.gif" height="35%">
 
 
-### Yayy!! You are done😃 
+### Yayy!! You are done😃
 

--- a/petoi_ROS_model_docs/docker-compose.yaml
+++ b/petoi_ROS_model_docs/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.4"
+
+services:
+  ros-rviz:
+    build:
+        context: .
+        dockerfile: Dockerfile
+    image: rviz_container:noetic
+    container_name: rviz_test
+    network_mode: "host"
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    privileged: true
+    environment:
+      - DISPLAY=$DISPLAY
+      - QT_X11_NO_MITSHM=1
+      - XAUTHORITY=/tmp/.docker.xauth
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - /tmp/.docker.xauth:/tmp/.docker.xauth:rw

--- a/petoi_ROS_model_docs/nybble_ros_documentation.md
+++ b/petoi_ROS_model_docs/nybble_ros_documentation.md
@@ -1,6 +1,6 @@
-# [Petoi](https://www.petoi.com/ "Petoi")  
+# [Petoi](https://www.petoi.com/ "Petoi")
 
-### Nybble ROS Documentation 
+### Nybble ROS Documentation
 This documentation is designed to configure Nybble in the ROS Simulation Environment.
 
 ### Pre-requisites 🤔
@@ -10,10 +10,10 @@ Your system must have:
 
 ### Tutorial 😃
 - #### [ROS Installation Steps](https://www.youtube.com/watch?v=ZA7u2XPmnlo)
-  
+
    Open the terminal and follow the below commands to install [ROS Noetic Ninjemys](http://wiki.ros.org/noetic/Installation/Ubuntu)
 
- 
+
 ```bash
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
  ```
@@ -21,52 +21,54 @@ Your system must have:
     sudo apt install curl # if you haven't already installed curl
  ```
 ```bash
- curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
+ curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 ```
 ```bash
 sudo apt update
 ```
-```bash 
-sudo apt install ros-noetic-desktop-full
+```bash
+sudo apt install ros-noetic-desktop-full ros-noetic-effort-controllers
 ```
 - #### Create Catkin Workspace for the ROS Packages
-  
 
-Follow the below mentioned commands to create a Catkin Workspace for creating and modifying the ROS packages. 
 
-```bash 
+Follow the below mentioned commands to create a Catkin Workspace for creating and modifying the ROS packages.
+
+```bash
 mkdir -p ~/catkin_ws/src
 ```
-```bash 
+```bash
 cd ~/catkin_ws/
 ```
-```bash 
+```bash
 catkin_make
 ```
-Open the ```~/.bashrc file``` via below command 
+Open the ```~/.bashrc file``` via below command
 
-```bash 
+```bash
 gedit ~/.bashrc
 ```
 .bashrc file will appear
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/bashrc.png" height ="100%" width="100%" alt text="bashrc file">
+<img src="bittle_ros_images/bashrc.png" height ="100%" width="100%" alt text="bashrc file">
 
 Paste the below commands in ```.bashrc file``` (screenshot has been attached for reference)
 
-```bash 
+```bash
 source /opt/ros/noetic/setup.bash
 source ~/catkin_ws/devel/setup.bash
 ```
 
 Clone the folder [nybble_description package](https://github.com/PetoiCamp/ros_opencat/tree/ros1/petoi_ros_docs/nybble_ros) and paste it inside the ```src``` folder of the catkin workspace.
 
+- #### Launch Gazebo simulation
+
 Start the ROS master via
 ```bash
 roscore
 ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/bittle_ros_images/roscore.png">
+<img src="bittle_ros_images/roscore.png">
 
 Open a new terminal window or simply press ```Ctrl+Alt+T```and follow below mentioned commands to spawn your Nybble in an empty Gazebo Simulation Environment.
 
@@ -86,11 +88,11 @@ ls
 roslaunch nybble_description gazebo.launch
 ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/final.png">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/nybble_simulation.png">
+<img src="nybble_ros_images/final.png">
+<img src="nybble_ros_images/nybble_simulation.png">
 
 - #### Steps to launch your Nybble in the Gazebo world Simulation Environment
-  
+
 <br>
 
 $${\color{red}CAUTION: \space \color{orange}Before \space launching \space your \space Nybble \space in \space the \space Gazebo \space World \space Simulation \space Environment \space you \space are \space first \space required \space to \space kill \space the \space existing }$$
@@ -105,7 +107,7 @@ $${\color{orange}processes. \space Just \space by \space simply \space pressing 
   roslaunch nybble_gazebo nybble_world.launch
   ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/nybble_world.png">
+<img src="nybble_ros_images/nybble_world.png">
 
 For launching controller for the joints of the Nybble.
 
@@ -114,8 +116,8 @@ For launching controller for the joints of the Nybble.
   ```
 Press the play button ▶️ in the Gazebo to load all the joint controllers.
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/controller_1.png">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/controller_2.png">
+<img src="nybble_ros_images/controller_1.png">
+<img src="nybble_ros_images/controller_2.png">
 
 For controlling the joint position of the neck you are required to install [joystick ros driver](http://wiki.ros.org/joy/Tutorials/ConfiguringALinuxJoystick) <br>
 [Video reference for installation of joystick driver](https://www.youtube.com/watch?v=4cSRdS83PX4&t=204s)
@@ -124,30 +126,30 @@ Open a new terminal window and launch your joystick package
 ```bash
   roslaunch nybble_joystick nybble_joystick.launch
   ```
-  
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/joystick_2.png">
 
-Open another terminal and run your joystick node 
+<img src="nybble_ros_images/joystick_2.png">
+
+Open another terminal and run your joystick node
 ```bash
   rosrun nybble_joystick nybble_joystick.py
   ```
 Press `Enter`
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/joystick_1.png">
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/joystick.jpeg">
+<img src="nybble_ros_images/joystick_1.png">
+<img src="nybble_ros_images/joystick.jpeg">
 
 Move this joystick button as mentioned in the above image to control the neck movement.
 
-To visualize your Nybble in Rviz(Robot Visualization) 
+To visualize your Nybble in Rviz(Robot Visualization)
 
 ```bash
    roslaunch nybble_description display.launch
   ```
 
-<img src="https://github.com/PetoiCamp/ros_opencat/blob/ros1/petoi_ros_docs/nybble_ros_images/rviz.png">
+<img src="nybble_ros_images/rviz.png">
 
 You can move the joints by sliding the corresponding joints bar using `joint_state_publisher_gui` node.
 
-### Yayy!! You are done😃 
+### Yayy!! You are done😃
 
 


### PR DESCRIPTION
This fixes the picture links in the docs, which were broken by https://github.com/PetoiCamp/ros_opencat/commit/3ad09b368ad7291c2b15319b8d95f4ceb28813eb
And also adds docker-compose and Dockerfile to run Gazebo examples inside container. 
Easier for people to try it out without installing ROS locally on the system.
There is a short README as well on how to run Gazebo / rviz from inside the container.